### PR TITLE
Add UXP environment check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-this is a plugin for PS.it can connect comfyui and ps to make some pictures.the plugin needs to connect a proxy servers,and then,the proxy would use a standerd issue of comfyui to send promt api.
+This is a Photoshop UXP plugin that connects ComfyUI with Photoshop to generate pictures.
+
+**Usage**
+1. Install the plugin in Photoshop using UXP Developer Tools or by copying this folder to the plugin directory.
+2. Open the panel named **绘影·AICG** from the Plugins menu.
+
+Opening `index.html` directly in a browser will not work because the code relies on UXP runtime APIs.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="./main.js"></script>
+    <script>
+      // Only load the main bundle when running inside Photoshop/UXP
+      if (typeof window.uxp !== 'undefined' || typeof require === 'function') {
+        const s = document.createElement('script');
+        s.src = './main.js';
+        document.head.appendChild(s);
+      } else {
+        document.addEventListener('DOMContentLoaded', () => {
+          const warning = document.createElement('p');
+          warning.textContent = 'Please install this plugin in Photoshop to run.';
+          warning.style.textAlign = 'center';
+          warning.style.fontFamily = 'sans-serif';
+          document.body.appendChild(warning);
+        });
+      }
+    </script>
   </head>
   <style>
     div {


### PR DESCRIPTION
## Summary
- show a warning when `index.html` is opened outside Photoshop
- update README with instructions for installing the plugin

## Testing
- `curl -s http://localhost:8000/index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_68695852c3bc8332948e1f05d6feea01